### PR TITLE
make files_ename_by_extension() more robust when handling a file without an extension

### DIFF
--- a/quick_feed.py
+++ b/quick_feed.py
@@ -69,9 +69,12 @@ vf = args.vf
 def files_ename_by_extension(directory, extension):
     f_list = {}
     for f in os.listdir(directory):
-	element_name, f_exten = f.lower().split(".")
-	if f_exten == extension:
-	    f_list[f] = element_name
+	try:
+            element_name, f_exten = f.lower().split(".")
+        except ValueError: # silently ignores files that don't have extensions, such as Icon files
+            continue
+        if f_exten == extension:
+            f_list[f] = element_name
     return f_list
 
 def check_db_flat(data_dir, sp):


### PR DESCRIPTION
quick_feed would choke on directories that contained files without an extension (like the Icon files that Google Drive creates), resulting in complete failure of the script. This fixes that problem by skipping over such files.
